### PR TITLE
feat: add copyExactName plugin option

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -1,11 +1,11 @@
-function extractArguments({ types, path, forDefaultExport }, node) {
+function extractArguments({ types, path, forDefaultExport }, node, opts) {
   if (node.type !== 'CallExpression') {
     return;
   }
 
   node.arguments = node.arguments.map(node => {
     if (types.isCallExpression(node)) {
-      extractArguments({ types, path, forDefaultExport }, node);
+      extractArguments({ types, path, forDefaultExport }, node, opts);
     }
 
     if (types.isIdentifier(node)) {
@@ -21,14 +21,18 @@ function extractArguments({ types, path, forDefaultExport }, node) {
     }
 
     const idName = forDefaultExport ? 'default' : path.node.id.name;
-    const id = path.scope.generateUidIdentifier(`${idName}_arg`);
 
+    if (opts.copyExactName) {
+      const key = types.identifier(idName);
+      const objectLiteral = types.objectExpression([types.objectProperty(key, node)]);
+      return types.memberExpression(objectLiteral, key);
+    }
+
+    const id = path.scope.generateUidIdentifier(`${idName}_arg`);
     path.insertBefore(
       types.assignmentExpression('=', id, node)
     );
-
     path.scope.push({ id });
-
     return id;
   });
 }
@@ -49,43 +53,41 @@ module.exports = function({ types }) {
     };
   }
 
-  const Visitor = {
-    VariableDeclarator(path) {
-      if (
-        path.parentPath.parent.type !== 'Program' &&
-        path.parentPath.parent.type !== 'ExportNamedDeclaration'
-        ) {
-        return;
-      }
-      if (!path.node.init) {
-        return;
-      }
-
-      if (path.node.init.type !== 'CallExpression') {
-        return;
-      }
-
-      extractArguments({ types, path }, path.node.init);
-    },
-
-    ExportDefaultDeclaration(path) {
-      if (path.node.declaration.type !== 'CallExpression') {
-        return;
-      }
-
-      extractArguments({
-        types,
-        path,
-        forDefaultExport: true
-      }, path.node.declaration);
-    }
-  };
-
   return {
     visitor: {
       Program: {
-        enter(path) {
-          path.traverse(Visitor);
+        enter(path, state) {
+          path.traverse({
+            VariableDeclarator(path) {
+              if (
+                path.parentPath.parent.type !== 'Program' &&
+                path.parentPath.parent.type !== 'ExportNamedDeclaration'
+                ) {
+                return;
+              }
+              if (!path.node.init) {
+                return;
+              }
+
+              if (path.node.init.type !== 'CallExpression') {
+                return;
+              }
+
+              extractArguments({ types, path }, path.node.init, state.opts);
+            },
+
+            ExportDefaultDeclaration(path) {
+              if (path.node.declaration.type !== 'CallExpression') {
+                return;
+              }
+
+              extractArguments({
+                types,
+                path,
+                forDefaultExport: true
+              }, path.node.declaration, state.opts);
+            }
+          });
         }
       }
     }

--- a/test/__snapshots__/babel.test.js.snap
+++ b/test/__snapshots__/babel.test.js.snap
@@ -40,3 +40,53 @@ var _final_arg = baz()(level0),
     _final_arg2 = bar()(_final_arg),
     final = foo()(_final_arg2);"
 `;
+
+exports[`extract HoCs with copyExactName for export default declaration 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _default_arg;
+
+var level0 = 1;
+_default_arg = {
+  default: bar()({
+    default: baz()(level0)
+  }.default)
+}.default
+exports.default = foo()(_default_arg);"
+`;
+
+exports[`extract HoCs with copyExactName for export named declaration 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+
+var _final_arg;
+
+var level0 = 1;
+var _final_arg = {
+  final: bar()({
+    final: baz()(level0)
+  }.final)
+}.final,
+    final = exports.final = foo()(_final_arg);"
+`;
+
+exports[`extract HoCs with copyExactName for variable declarator 1`] = `
+"\\"use strict\\";
+
+var _final_arg;
+
+var level0 = 1;
+var _final_arg = {
+  final: bar()({
+    final: baz()(level0)
+  }.final)
+}.final,
+    final = foo()(_final_arg);"
+`;

--- a/test/babel.test.js
+++ b/test/babel.test.js
@@ -8,22 +8,34 @@ function trim(str) {
   return str.replace(/^\s+|\s+$/, '')
 }
 
-describe('extract HoCs', () => {
+function specsFromFixtures(cb) {
   fs.readdirSync(FIXTURES_DIR).forEach(fixtureName => {
     const fixtureFile = path.join(FIXTURES_DIR, fixtureName)
 
     if (fs.statSync(fixtureFile).isFile()) {
       const caseName = fixtureName.replace(/\.js$/, '').split('-').join(' ')
 
-      it(`for ${caseName}`, () => {
-        const actual = transformFileSync(fixtureFile).code
-        const codeWithoutFilename = actual.replace(
-          new RegExp(`["']${fixtureFile}["']`, 'g'),
-          '__FILENAME__',
-        )
-
-        expect(trim(codeWithoutFilename)).toMatchSnapshot()
-      })
+      it(`for ${caseName}`, () => cb({ fixtureFile }))
     }
   })
-})
+}
+
+describe('extract HoCs', () => specsFromFixtures(({ fixtureFile }) => {
+  const actual = transformFileSync(fixtureFile).code
+  const codeWithoutFilename = actual.replace(
+    new RegExp(`["']${fixtureFile}["']`, 'g'),
+    '__FILENAME__',
+  );
+
+  expect(trim(codeWithoutFilename)).toMatchSnapshot();
+}));
+
+describe('extract HoCs with copyExactName', () => specsFromFixtures(({ fixtureFile }) => {
+  const actual = transformFileSync(fixtureFile, { plugins: [['../../lib/babel', { copyExactName: true }]] }).code
+  const codeWithoutFilename = actual.replace(
+    new RegExp(`["']${fixtureFile}["']`, 'g'),
+    '__FILENAME__',
+  );
+
+  expect(trim(codeWithoutFilename)).toMatchSnapshot();
+}));


### PR DESCRIPTION
I added another approach that can optionally be enabled with the copyExactName flag. This way exact function names will be preserved.