### PR TITLE
Remove noop for production

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -42,13 +42,6 @@ function pathToInsertAssignments(path) {
 }
 
 module.exports = function({ types }) {
-  // No-op in production.
-  if (process.env.NODE_ENV === 'production') {
-    return {
-      visitor: {}
-    };
-  }
-
   const Visitor = {
     VariableDeclarator(path) {
       if (


### PR DESCRIPTION
I think it's best to make it more flexible by removing the prod env check and letting the user handle this in babel config.